### PR TITLE
Fix Commitizen version file path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ build-backend = "poetry.core.masonry.api"
 name = "cz_conventional_commits"
 version = "0.0.1"
 tag_format = "$version"
-version_files = ["pyproject.toml:version", "eclypse/__init__.py:__version__"]
+version_files = ["pyproject.toml:version", "spaceai/__init__.py:__version__"]
 
 [tool.pycln]
 all = true


### PR DESCRIPTION
## Summary
- correct the path for `tool.commitizen` version_files

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_6873b368be648328b831071b67dd1fd6