### PR TITLE
Add realistic fixtures and workflow test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     hooks:
       - id: isort
         args: ['--profile', 'black']
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ pip install poetry
 
 git clone https://github.com/continualist/space-ai.git
 cd space-ai
+# install runtime dependencies
 poetry install
+# install optional testing dependencies
+poetry install --with test
 poetry run pre-commit install
+# build the Cython extension used by the segmentators
+python spaceai/segmentators/setup.py build_ext --inplace
+```
+
+### Running the examples
+
+To train a baseline model on the ESA dataset run:
+
+```sh
+poetry run python examples/esa_competition_experiment.py
+```
+
+You can then perform inference using:
+
+```sh
+poetry run python examples/labeller.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,10 @@ black = true
 testpaths = "tests"
 addopts = "--cov-report=xml --cov-report=term-missing --cov"
 filterwarnings = ["ignore::DeprecationWarning"]
+
+[tool.poetry.extras]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,158 @@
+import sys
+import types
+
+mod = types.ModuleType("spaceai.data.ops_sat")
+setattr(mod, "OPSSAT", object())
+sys.modules.setdefault("spaceai.data.ops_sat", mod)
+bench_mod = types.ModuleType("spaceai.benchmark.ops_sat")
+setattr(bench_mod, "OPSSATBenchmark", object)
+sys.modules.setdefault("spaceai.benchmark.ops_sat", bench_mod)
+
+# Provide a minimal torch substitute for tests
+torch_mod = types.ModuleType("torch")
+utils_mod = types.ModuleType("torch.utils")
+data_mod = types.ModuleType("torch.utils.data")
+setattr(data_mod, "Dataset", object)
+setattr(data_mod, "DataLoader", object)
+setattr(data_mod, "Subset", object)
+setattr(utils_mod, "data", data_mod)
+setattr(torch_mod, "utils", utils_mod)
+setattr(torch_mod, "tensor", lambda x: x)
+setattr(torch_mod, "Tensor", object)
+sys.modules.setdefault("torch", torch_mod)
+sys.modules.setdefault("torch.utils", utils_mod)
+sys.modules.setdefault("torch.utils.data", data_mod)
+
+# Stub heavy optional dependencies used only during imports
+rocket_mod = types.ModuleType("sktime.transformations.panel.rocket")
+setattr(rocket_mod, "Rocket", object)
+sys.modules.setdefault("sktime", types.ModuleType("sktime"))
+transforms_mod = types.ModuleType("sktime.transformations")
+sys.modules.setdefault("sktime.transformations", transforms_mod)
+sys.modules.setdefault(
+    "sktime.transformations.base", types.ModuleType("sktime.transformations.base")
+)
+setattr(sys.modules["sktime.transformations.base"], "BaseTransformer", object)
+sys.modules.setdefault(
+    "sktime.transformations.panel", types.ModuleType("sktime.transformations.panel")
+)
+sys.modules.setdefault("sktime.transformations.panel.rocket", rocket_mod)
+
+numba_mod = types.ModuleType("numba")
+setattr(numba_mod, "prange", range)
+sys.modules.setdefault("numba", numba_mod)
+
+tslearn_mod = types.ModuleType("tslearn")
+cluster_mod = types.ModuleType("tslearn.clustering")
+setattr(cluster_mod, "TimeSeriesKMeans", object)
+setattr(tslearn_mod, "clustering", cluster_mod)
+sys.modules.setdefault("tslearn", tslearn_mod)
+sys.modules.setdefault("tslearn.clustering", cluster_mod)
+
+# skopt is used for Bayesian optimization; a minimal stub suffices
+skopt_space_mod = types.ModuleType("skopt.space")
+setattr(skopt_space_mod, "Dimension", object)
+sys.modules.setdefault("skopt", types.ModuleType("skopt"))
+sys.modules.setdefault("skopt.space", skopt_space_mod)
+
+# simple placeholder for pymannkendall used in feature functions
+pymk_mod = types.ModuleType("pymannkendall")
+sys.modules.setdefault("pymannkendall", pymk_mod)
+
+# Minimal pyarrow parquet stub to avoid optional dependency
+pyarrow_parquet_mod = types.ModuleType("pyarrow.parquet")
+
+
+def _fake_read_table(path):
+    import pandas as pd
+
+    dates = pd.date_range("2000-01-01", periods=20, freq="30S")
+    return pd.DataFrame(
+        {"channel_12": range(20), "channel_41": range(20), "telecommand_1": 0},
+        index=dates,
+    )
+
+
+setattr(
+    pyarrow_parquet_mod,
+    "read_table",
+    lambda path: types.SimpleNamespace(to_pandas=lambda: _fake_read_table(path)),
+)
+pyarrow_mod = types.ModuleType("pyarrow")
+setattr(pyarrow_mod, "__version__", "0.0")
+sys.modules.setdefault("pyarrow", pyarrow_mod)
+sys.modules.setdefault("pyarrow.parquet", pyarrow_parquet_mod)
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from spaceai.data.esa import (
+    ESA,
+    ESAMissions,
+)
+
+
+@pytest.fixture
+def sample_dataset(tmp_path):
+    """Create a tiny ESA-like dataset with two channels and one telecommand."""
+
+    mission = ESAMissions.MISSION_1.value
+    base = tmp_path / mission.dirname / mission.dirname
+    channels = base / "channels"
+    telecommands_dir = base / "telecommands"
+    channels.mkdir(parents=True)
+    telecommands_dir.mkdir(parents=True)
+
+    # 20 timesteps spaced according to mission sampling rule
+    dates = pd.date_range(mission.start_date, periods=20, freq=mission.resampling_rule)
+
+    ch12 = pd.DataFrame({"channel_12": np.arange(20)}, index=dates)
+    ch41 = pd.DataFrame({"channel_41": np.arange(20) * 2}, index=dates)
+    ch12.to_pickle(channels / "channel_12.zip")
+    ch41.to_pickle(channels / "channel_41.zip")
+
+    # telecommand executed twice
+    tc_df = pd.DataFrame({"value": [1, 1]}, index=[dates[5], dates[15]])
+    tc_df.to_pickle(telecommands_dir / "telecommand_1.zip")
+
+    labels = pd.DataFrame(
+        {
+            "ID": [1],
+            "Channel": ["channel_12"],
+            "StartTime": [dates[8]],
+            "EndTime": [dates[10]],
+        }
+    )
+    labels.to_csv(base / "labels.csv", index=False)
+    anomaly_types = pd.DataFrame({"ID": [1], "Category": ["Anomaly"]})
+    anomaly_types.to_csv(base / "anomaly_types.csv", index=False)
+
+    telecommands_csv = pd.DataFrame({"Telecommand": ["telecommand_1"], "Priority": [3]})
+    telecommands_csv.to_csv(base / "telecommands.csv", index=False)
+
+    channels_csv = pd.DataFrame(
+        {"Channel": ["channel_12", "channel_41"], "Group": [0, 0]}
+    )
+    channels_csv.to_csv(base / "channels.csv", index=False)
+
+    return tmp_path
+
+
+def make_esa(root: Path, channel_id: str = "channel_12") -> ESA:
+    """Return an ESA object pointing to the temporary dataset."""
+
+    mission = ESAMissions.MISSION_1.value
+    return ESA(
+        root=str(root),
+        mission=mission,
+        channel_id=channel_id,
+        mode="anomaly",
+        overlapping=False,
+        seq_length=2,
+        n_predictions=1,
+        train=True,
+        download=False,
+        use_telecommands=True,
+    )

--- a/tests/test_esa_loading.py
+++ b/tests/test_esa_loading.py
@@ -1,0 +1,9 @@
+from conftest import make_esa
+
+from spaceai.data.esa import ESAMissions
+
+
+def test_load_channel(sample_dataset):
+    esa = make_esa(sample_dataset, "channel_12")
+    assert esa.data.shape == (20, 2)
+    assert esa.anomalies == [(8, 10)]

--- a/tests/test_segmentator.py
+++ b/tests/test_segmentator.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from conftest import make_esa
+
+from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
+
+
+def test_segmentator_columns(sample_dataset, monkeypatch):
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", lambda self, *a, **k: None)
+    esa = make_esa(sample_dataset, "channel_12")
+    segmentator = EsaDatasetSegmentator2(
+        transformations=["mean", "max"],
+        run_id="t",
+        exp_dir=str(sample_dataset / "exp"),
+        segment_duration=2,
+        step_duration=1,
+        telecommands=False,
+        poolings=[],
+        use_shapelets=False,
+        step_difference_feature=False,
+    )
+    df, _ = segmentator.segment(esa, [], "e1", train_phase=True)
+    assert set(["start", "end", "mean", "max"]).issubset(df.columns)

--- a/tests/test_shapelet_miner.py
+++ b/tests/test_shapelet_miner.py
@@ -1,0 +1,58 @@
+import random
+
+import numpy as np
+from conftest import make_esa
+
+from spaceai.segmentators.shapelet_miner import ShapeletMiner
+
+
+def test_shapelet_miner_deterministic(sample_dataset, monkeypatch):
+    esa = make_esa(sample_dataset, "channel_12")
+
+    orig_rng = np.random.default_rng
+
+    def fixed_rng(seed=None):
+        return orig_rng(0)
+
+    monkeypatch.setattr(np.random, "default_rng", fixed_rng)
+    random.seed(0)
+
+    def fake_score(self, *a, **k):
+        return [np.array([1.0, 0.0])], np.array([1.0])
+
+    monkeypatch.setattr(ShapeletMiner, "score_anomaly_kernels", fake_score)
+    monkeypatch.setattr(
+        ShapeletMiner,
+        "select_best_kernels",
+        lambda self, kernels, scores, num_kernels=None: kernels,
+    )
+
+    miner1 = ShapeletMiner(
+        k_min_length=2,
+        k_max_length=2,
+        num_kernels=1,
+        segment_duration=2,
+        step_duration=1,
+        run_id="t",
+        exp_dir=str(sample_dataset / "exp"),
+        skip=False,
+    )
+    miner1.initialize_kernels(esa, (0, len(esa.data)), "e1")
+    kernels1 = [k.tolist() for k in miner1.kernels]
+
+    monkeypatch.setattr(np.random, "default_rng", fixed_rng)
+    random.seed(0)
+    miner2 = ShapeletMiner(
+        k_min_length=2,
+        k_max_length=2,
+        num_kernels=1,
+        segment_duration=2,
+        step_duration=1,
+        run_id="t",
+        exp_dir=str(sample_dataset / "exp2"),
+        skip=False,
+    )
+    miner2.initialize_kernels(esa, (0, len(esa.data)), "e2")
+    kernels2 = [k.tolist() for k in miner2.kernels]
+
+    assert kernels1 == kernels2

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,44 @@
+from spaceai.benchmark.esa_competition import ESACompetitionBenchmark
+from spaceai.data.esa import ESAMissions
+from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
+from spaceai.segmentators.shapelet_miner import ShapeletMiner
+
+
+def test_competition_workflow(tmp_path, sample_dataset, monkeypatch):
+    mission = ESAMissions.MISSION_1.value
+    mission.target_channels = ["channel_41"]
+
+    shapelet_miner = ShapeletMiner(
+        k_min_length=2,
+        k_max_length=2,
+        num_kernels=1,
+        segment_duration=2,
+        step_duration=1,
+        run_id="wf",
+        exp_dir=str(tmp_path / "exp"),
+        skip=True,
+    )
+    segmentator = EsaDatasetSegmentator2(
+        transformations=["mean", "max"],
+        run_id="wf",
+        exp_dir=str(tmp_path / "exp"),
+        shapelet_miner=shapelet_miner,
+        segment_duration=2,
+        step_duration=1,
+        telecommands=True,
+        poolings=[],
+        use_shapelets=False,
+        step_difference_feature=False,
+    )
+
+    benchmark = ESACompetitionBenchmark(
+        run_id="wf",
+        exp_dir=str(tmp_path / "exp"),
+        data_root=str(sample_dataset),
+        segmentator=segmentator,
+        seed=0,
+    )
+
+    train_ch, test_ch = benchmark.load_channel(mission, "channel_41")
+    assert train_ch.channel_id == "channel_41"
+    assert test_ch.channel_id == "channel_41"


### PR DESCRIPTION
## Summary
- improve test fixtures with ESA-like data
- stub heavy dependencies for tests
- adjust tests for new dataset
- add simple workflow test using the benchmark loader

## Testing
- `pre-commit run --files tests/conftest.py tests/test_esa_loading.py tests/test_segmentator.py tests/test_shapelet_miner.py tests/test_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_6873b9aef8808328a860aef2b5fa4f68