### PR TITLE
Add inference pipeline and training script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir poetry \
+    && poetry install --no-dev
+
+RUN python spaceai/segmentators/setup.py build_ext --inplace
+
+CMD ["python", "inference.py", "--test-parquet", "/data/test.parquet", "--artifacts-dir", "/artifacts", "--output", "/data/submission.csv"]

--- a/esa_competition_training.py
+++ b/esa_competition_training.py
@@ -1,0 +1,97 @@
+import argparse
+import os
+from functools import partial
+
+import more_itertools as mit
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import make_scorer
+from sklearn.model_selection import TimeSeriesSplit
+from skopt import BayesSearchCV
+from skopt.space import (
+    Integer,
+    Real,
+)
+
+from spaceai.benchmark import ESACompetitionBenchmark
+from spaceai.data import ESAMissions
+from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
+from spaceai.segmentators.shapelet_miner import ShapeletMiner
+from spaceai.utils.callbacks import SystemMonitorCallback
+
+
+def esa_scorer(y_val, y_pred, benchmark):
+    pred_anomalies = benchmark.process_pred_anomalies(y_pred, 0)
+    indices = np.where(y_val == 1)[0]
+    groups = [list(group) for group in mit.consecutive_groups(indices)]
+    true_anomalies = [[group[0], group[-1]] for group in groups]
+    res = benchmark.compute_classification_metrics(true_anomalies, pred_anomalies)
+    esa_res = benchmark.compute_esa_classification_metrics(
+        res, true_anomalies, pred_anomalies, len(y_val)
+    )
+    return esa_res["f0.5"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ESA competition training")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--exp-dir", default="experiments")
+    parser.add_argument("--data-root", default="datasets")
+    args = parser.parse_args()
+
+    shapelet_miner = ShapeletMiner(
+        k_min_length=1599,
+        k_max_length=1600,
+        num_kernels=5,
+        segment_duration=1000,
+        step_duration=200,
+        run_id=args.run_id,
+        exp_dir=args.exp_dir,
+    )
+
+    segmentator = EsaDatasetSegmentator2(
+        transformations=["min", "max", "mean", "std"],
+        segment_duration=1000,
+        step_duration=200,
+        shapelet_miner=shapelet_miner,
+        telecommands=False,
+        poolings=["max", "min"],
+        run_id=args.run_id,
+        exp_dir=args.exp_dir,
+        use_shapelets=True,
+    )
+
+    benchmark = ESACompetitionBenchmark(
+        run_id=args.run_id,
+        exp_dir=args.exp_dir,
+        data_root=args.data_root,
+        segmentator=segmentator,
+    )
+
+    lr_param_space = {
+        "C": Real(1e-4, 1e2, prior="log-uniform"),
+    }
+    lr_classifier = LogisticRegression(max_iter=1000, solver="liblinear")
+    search_cv_factory = lambda: BayesSearchCV(
+        estimator=lr_classifier,
+        search_spaces=lr_param_space,
+        scoring=make_scorer(
+            partial(esa_scorer, benchmark=benchmark), greater_is_better=True
+        ),
+        cv=TimeSeriesSplit(n_splits=3),
+        n_iter=10,
+        n_jobs=-1,
+    )
+
+    mission = ESAMissions.MISSION_1.value
+    benchmark.run(
+        mission=mission,
+        search_cv_factory=search_cv_factory,
+        search_cv_factory2=search_cv_factory,
+        search_cv_factory3=search_cv_factory,
+        skip_channel_training=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,44 @@
+import argparse
+
+from spaceai.benchmark.esa_competition_predictor import ESACompetitionPredictor
+from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
+from spaceai.segmentators.shapelet_miner import ShapeletMiner
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ESA competition inference")
+    parser.add_argument("--artifacts-dir", required=True)
+    parser.add_argument("--test-parquet", required=True)
+    parser.add_argument("--output", default="submission.csv")
+    args = parser.parse_args()
+
+    shapelet_miner = ShapeletMiner(
+        k_min_length=1599,
+        k_max_length=1600,
+        num_kernels=5,
+        segment_duration=1000,
+        step_duration=200,
+        run_id=args.artifacts_dir.split("/")[-1],
+        exp_dir=args.artifacts_dir,
+        skip=True,
+    )
+
+    segmentator = EsaDatasetSegmentator2(
+        transformations=["min", "max", "mean", "std"],
+        segment_duration=1000,
+        step_duration=200,
+        shapelet_miner=shapelet_miner,
+        telecommands=False,
+        poolings=["max", "min"],
+        run_id=args.artifacts_dir.split("/")[-1],
+        exp_dir=args.artifacts_dir,
+        use_shapelets=True,
+    )
+
+    predictor = ESACompetitionPredictor(args.artifacts_dir, segmentator)
+    predictor.load_models()
+    predictor.predict(args.test_parquet, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/spaceai/benchmark/__init__.py
+++ b/spaceai/benchmark/__init__.py
@@ -2,5 +2,12 @@ from .benchmark import Benchmark
 from .esa import ESABenchmark
 from .ops_sat import OPSSATBenchmark
 from .esa_competition import ESACompetitionBenchmark
+from .esa_competition_predictor import ESACompetitionPredictor
 
-__all__ = ["Benchmark", "ESABenchmark", "OPSSATBenchmark", "ESACompetitionBenchmark"]
+__all__ = [
+    "Benchmark",
+    "ESABenchmark",
+    "OPSSATBenchmark",
+    "ESACompetitionBenchmark",
+    "ESACompetitionPredictor",
+]

--- a/spaceai/benchmark/esa_competition_predictor.py
+++ b/spaceai/benchmark/esa_competition_predictor.py
@@ -1,0 +1,119 @@
+import glob
+import os
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from spaceai.data import (
+    ESA,
+    ESAMissions,
+)
+from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
+
+from .esa_competition import ESACompetitionBenchmark
+
+
+class ESACompetitionPredictor:
+    """Load training artefacts and run inference on new data."""
+
+    def __init__(self, artifacts_dir: str, segmentator: EsaDatasetSegmentator2) -> None:
+        self.artifacts_dir = artifacts_dir
+        self.segmentator = segmentator
+        self.channel_models: dict[str, list] = {}
+        self.event_models: list = []
+        self.run_id = os.path.basename(os.path.normpath(artifacts_dir))
+        self.benchmark = ESACompetitionBenchmark(
+            run_id=self.run_id,
+            exp_dir=os.path.dirname(artifacts_dir),
+            segmentator=segmentator,
+        )
+
+    def load_models(self) -> None:
+        """Load serialized models from ``artifacts_dir``."""
+        model_base = os.path.join(self.artifacts_dir, "models")
+        for ch_dir in glob.glob(os.path.join(model_base, "channel_*")):
+            ch_id = os.path.basename(ch_dir).split("_")[1]
+            models = [
+                joblib.load(p) for p in sorted(glob.glob(os.path.join(ch_dir, "*.pkl")))
+            ]
+            self.channel_models[ch_id] = models
+        self.event_models = [
+            joblib.load(p)
+            for p in sorted(glob.glob(os.path.join(model_base, "event_wise_*.pkl")))
+        ]
+
+    def predict(self, test_parquet: str, output: str) -> None:
+        """Run the inference pipeline and produce ``submission.csv``."""
+        data_root = os.path.dirname(os.path.dirname(test_parquet))
+        mission = ESAMissions.MISSION_1.value
+
+        source_folder = os.path.join(data_root, mission.inner_dirpath)
+        meta = pd.read_csv(os.path.join(source_folder, "channels.csv")).assign(
+            Channel=lambda d: d.Channel.str.strip()
+        )
+        groups = (
+            meta[meta["Channel"].isin(mission.target_channels)]
+            .groupby("Group")["Channel"]
+            .apply(list)
+            .to_dict()
+        )
+
+        global_df = None
+        channel_cv = {}
+        for channel_id, models in self.channel_models.items():
+            esa_channel = ESA(
+                root=data_root,
+                mission=mission,
+                channel_id=f"{channel_id}",
+                mode="challenge",
+                train=False,
+            )
+            df, _ = self.segmentator.segment(
+                esa_channel, masks=[], ensemble_id="challenge", train_phase=False
+            )
+            proba = np.mean(
+                [
+                    (
+                        mdl.predict_proba(df)[:, 1]
+                        if mdl.predict_proba(df).shape[1] > 1
+                        else np.full(len(df), 1.0 if mdl.classes_[0] == 1 else 0.0)
+                    )
+                    for mdl in models
+                ],
+                axis=0,
+            )
+            if global_df is None:
+                global_df = pd.DataFrame({"start": df["start"], "end": df["end"]})
+            global_df[channel_id] = proba
+            channel_cv[channel_id] = 1.0
+
+        if global_df is None:
+            raise RuntimeError("No channels loaded")
+
+        global_df = self.benchmark.add_group_activation(global_df, groups, channel_cv)
+
+        X = global_df[[c for c in global_df.columns if c.startswith("group_")]]
+        fold_probas = []
+        for mdl in self.event_models:
+            p = mdl.predict_proba(X)
+            if p.shape[1] == 1:
+                single = mdl.classes_[0]
+                p = np.full(len(X), 1.0 if single == 1 else 0.0)
+            else:
+                p = p[:, 1]
+            fold_probas.append(p)
+
+        final_probas = np.max(fold_probas, axis=0) - np.var(fold_probas, axis=0)
+        y_full, y_binary = self.benchmark.predict_challenge_labels(
+            challenge_test=global_df,
+            challenge_probas=final_probas,
+        )
+        out_df = pd.DataFrame(
+            {
+                "id": np.arange(len(y_full)) + self.benchmark.id_offset,
+                "is_anomaly": y_full,
+                "pred_binary": y_binary,
+            }
+        )
+        out_df.to_csv(output, index=False)


### PR DESCRIPTION
## Summary
- add joblib serialization of models
- implement `ESACompetitionPredictor` for inference
- provide training helper script
- include inference script and Dockerfile
- export predictor in benchmark init

## Testing
- `pre-commit run --files spaceai/benchmark/__init__.py spaceai/benchmark/esa_competition.py spaceai/benchmark/esa_competition_predictor.py esa_competition_training.py inference.py Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_6874e10791748328806c80c1db6b2607