### PR TITLE
Implement workflow tests

### DIFF
--- a/spaceai/benchmark/esa_competition_predictor.py
+++ b/spaceai/benchmark/esa_competition_predictor.py
@@ -1,98 +1,157 @@
+from __future__ import annotations
+
 import glob
+import json
 import os
+from typing import Any, Dict, List, Optional
 
 import joblib
 import numpy as np
 import pandas as pd
 
-from spaceai.data import (
-    ESA,
-    ESAMissions,
-)
+from spaceai.data import ESA, ESAMission, ESAMissions
 from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
 
 from .esa_competition import ESACompetitionBenchmark
 
 
-class ESACompetitionPredictor:
-    """Load training artefacts and run inference on new data."""
+class ESACompetitionPredictor(ESACompetitionBenchmark):
+    """Benchmark variant used only for inference.
 
-    def __init__(self, artifacts_dir: str, segmentator: EsaDatasetSegmentator2) -> None:
-        self.artifacts_dir = artifacts_dir
-        self.segmentator = segmentator
-        self.channel_models: dict[str, list] = {}
-        self.event_models: list = []
-        self.run_id = os.path.basename(os.path.normpath(artifacts_dir))
-        self.benchmark = ESACompetitionBenchmark(
-            run_id=self.run_id,
+    It mirrors :class:`ESACompetitionBenchmark` but loads the models
+    previously saved by :class:`ESACompetitionTraining` and applies them
+    to new challenge data.
+    """
+
+    def __init__(
+        self,
+        artifacts_dir: str,
+        segmentator: Optional[EsaDatasetSegmentator2],
+        data_root: str = "datasets",
+        id_offset: int = 14728321,
+        seed: int = 42,
+    ) -> None:
+        run_id = os.path.basename(os.path.normpath(artifacts_dir))
+        super().__init__(
+            run_id=run_id,
             exp_dir=os.path.dirname(artifacts_dir),
             segmentator=segmentator,
+            data_root=data_root,
+            id_offset=id_offset,
+            seed=seed,
         )
+        self.artifacts_dir = artifacts_dir
+        self.internal_models: Dict[str, Any] = {}
+        self.meta_models: Dict[str, Any] = {}
+        self.event_models: List[Any] = []
+        self.channel_links: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
+    # ------------------------------------------------------------------
+    # Loading utilities
+    # ------------------------------------------------------------------
     def load_models(self) -> None:
         """Load serialized models from ``artifacts_dir``."""
         model_base = os.path.join(self.artifacts_dir, "models")
         for ch_dir in glob.glob(os.path.join(model_base, "channel_*")):
-            ch_id = os.path.basename(ch_dir).split("_")[1]
-            models = [
-                joblib.load(p) for p in sorted(glob.glob(os.path.join(ch_dir, "*.pkl")))
-            ]
-            self.channel_models[ch_id] = models
-        self.event_models = [
-            joblib.load(p)
-            for p in sorted(glob.glob(os.path.join(model_base, "event_wise_*.pkl")))
-        ]
+            base = os.path.basename(ch_dir)
+            ch_id = base[len("channel_") :]
+            links_file = os.path.join(ch_dir, "links.json")
+            if os.path.exists(links_file):
+                with open(links_file, "r") as f:
+                    self.channel_links[ch_id] = json.load(f)
+            for p in glob.glob(os.path.join(ch_dir, "internal_*.pkl")):
+                mid = os.path.splitext(os.path.basename(p))[0]
+                self.internal_models[mid] = joblib.load(p)
+            for p in glob.glob(os.path.join(ch_dir, "external_*.pkl")):
+                mid = os.path.splitext(os.path.basename(p))[0]
+                self.meta_models[mid] = joblib.load(p)
+        for p in glob.glob(os.path.join(model_base, "event_wise_*.pkl")):
+            self.event_models.append(joblib.load(p))
 
-    def predict(self, test_parquet: str, output: str) -> None:
-        """Run the inference pipeline and produce ``submission.csv``."""
-        data_root = os.path.dirname(os.path.dirname(test_parquet))
-        mission = ESAMissions.MISSION_1.value
+    # ------------------------------------------------------------------
+    #  Inference helpers
+    # ------------------------------------------------------------------
+    def channel_specific_ensemble(self, challenge_channel: ESA, channel_id: str) -> pd.DataFrame:
+        """Apply all saved estimators for ``channel_id`` on ``challenge_channel``."""
+        links = self.channel_links.get(channel_id, {})
+        if not links:
+            raise RuntimeError(f"No model links found for channel {channel_id}")
 
-        source_folder = os.path.join(data_root, mission.inner_dirpath)
-        meta = pd.read_csv(os.path.join(source_folder, "channels.csv")).assign(
-            Channel=lambda d: d.Channel.str.strip()
-        )
-        groups = (
-            meta[meta["Channel"].isin(mission.target_channels)]
-            .groupby("Group")["Channel"]
-            .apply(list)
-            .to_dict()
-        )
+        df_out: Optional[pd.DataFrame] = None
+        meta_probas = []
+        for meta_id, info in links.items():
+            internal_ids = info.get("internal_ids", [])
+            internal_probas = []
+            first_df: Optional[pd.DataFrame] = None
+            for iid in internal_ids:
+                mdl = self.internal_models[iid]
+                mdl.segmentator.shapelet_miner.initialize_kernels(
+                    challenge_channel,
+                    mask=(0, len(challenge_channel.data)),
+                    ensemble_id=mdl.ensemble_id,
+                )
+                df, _ = mdl.segmentator.segment(
+                    challenge_channel, masks=[], ensemble_id=mdl.ensemble_id, train_phase=False
+                )
+                if first_df is None:
+                    first_df = df
+                p = mdl.model.predict_proba(df)
+                if p.shape[1] == 1:
+                    cls = mdl.model.classes_[0]
+                    internal_probas.append(np.full(len(df), 1.0 if cls == 1 else 0.0))
+                else:
+                    internal_probas.append(p[:, 1])
 
-        global_df = None
-        channel_cv = {}
-        for channel_id, models in self.channel_models.items():
-            esa_channel = ESA(
-                root=data_root,
-                mission=mission,
-                channel_id=f"{channel_id}",
-                mode="challenge",
-                train=False,
-            )
-            df, _ = self.segmentator.segment(
-                esa_channel, masks=[], ensemble_id="challenge", train_phase=False
-            )
-            proba = np.mean(
-                [
-                    (
-                        mdl.predict_proba(df)[:, 1]
-                        if mdl.predict_proba(df).shape[1] > 1
-                        else np.full(len(df), 1.0 if mdl.classes_[0] == 1 else 0.0)
-                    )
-                    for mdl in models
-                ],
-                axis=0,
-            )
+            meta_df = pd.DataFrame({f"channel_{i}": internal_probas[i] for i in range(len(internal_probas))})
+            meta_mdl = self.meta_models[meta_id]
+            mp = meta_mdl.model.predict_proba(meta_df)
+            if mp.shape[1] == 1:
+                cls = meta_mdl.model.classes_[0]
+                mp = np.full(len(meta_df), 1.0 if cls == 1 else 0.0)
+            else:
+                mp = mp[:, 1]
+            meta_probas.append(mp)
+            if df_out is None and first_df is not None:
+                df_out = first_df[["start", "end"]].copy()
+
+        mean_proba = np.mean(meta_probas, axis=0)
+        if df_out is None:
+            raise RuntimeError("No channel data processed")
+        df_out[channel_id] = mean_proba
+        return df_out
+
+    def run(
+        self,
+        mission: ESAMission,
+        peak_height: float = 0.5,
+        buffer_size: int = 100,
+        gamma: float = 1.5,
+        delta: float = 0.05,
+        beta: float = 0.3,
+    ) -> pd.DataFrame:
+        """Execute the inference pipeline on the challenge data."""
+        if not self.meta_models:
+            self.load_models()
+
+        source_folder = os.path.join(self.data_root, mission.inner_dirpath)
+        meta = pd.read_csv(os.path.join(source_folder, "channels.csv")).assign(Channel=lambda d: d.Channel.str.strip())
+        groups = meta[meta["Channel"].isin(mission.target_channels)].groupby("Group")["Channel"].apply(list).to_dict()
+
+        global_df: Optional[pd.DataFrame] = None
+        channel_cv: Dict[str, float] = {}
+        for channel_id in mission.target_channels:
+            _, challenge_channel = self.load_channel(mission, channel_id, overlapping_train=False)
+            df_ch = self.channel_specific_ensemble(challenge_channel, channel_id)
             if global_df is None:
-                global_df = pd.DataFrame({"start": df["start"], "end": df["end"]})
-            global_df[channel_id] = proba
+                global_df = df_ch
+            else:
+                global_df = global_df.merge(df_ch, on=["start", "end"], how="outer")
             channel_cv[channel_id] = 1.0
 
         if global_df is None:
-            raise RuntimeError("No channels loaded")
+            raise RuntimeError("No channels processed")
 
-        global_df = self.benchmark.add_group_activation(global_df, groups, channel_cv)
-
+        global_df = self.add_group_activation(global_df, groups, channel_cv, gamma=gamma, delta=delta, beta=beta)
         X = global_df[[c for c in global_df.columns if c.startswith("group_")]]
         fold_probas = []
         for mdl in self.event_models:
@@ -105,15 +164,30 @@ class ESACompetitionPredictor:
             fold_probas.append(p)
 
         final_probas = np.max(fold_probas, axis=0) - np.var(fold_probas, axis=0)
-        y_full, y_binary = self.benchmark.predict_challenge_labels(
+        y_full, y_binary = self.predict_challenge_labels(
             challenge_test=global_df,
             challenge_probas=final_probas,
+            peak_height=peak_height,
+            buffer_size=buffer_size,
         )
-        out_df = pd.DataFrame(
+        return pd.DataFrame(
             {
-                "id": np.arange(len(y_full)) + self.benchmark.id_offset,
+                "id": np.arange(len(y_full)) + self.id_offset,
                 "is_anomaly": y_full,
                 "pred_binary": y_binary,
             }
         )
-        out_df.to_csv(output, index=False)
+
+    def predict(
+        self,
+        test_parquet: str,
+        output: str,
+        mission: Optional[ESAMission] = None,
+    ) -> None:
+        """Convenience wrapper to run inference given a parquet file path."""
+        data_root = os.path.dirname(os.path.dirname(test_parquet))
+        if mission is None:
+            mission = ESAMissions.MISSION_1.value
+        self.data_root = data_root
+        df = self.run(mission)
+        df.to_csv(output, index=False)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,259 @@
+import glob
+import os
+import sys
+import types
+from datetime import datetime, timedelta
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+ops_sat_stub = types.ModuleType("spaceai.data.ops_sat")
+class DummyOPSSAT:
+    pass
+ops_sat_stub.OPSSAT = DummyOPSSAT
+sys.modules.setdefault("spaceai.data.ops_sat", ops_sat_stub)
+bench_ops_sat = types.ModuleType("spaceai.benchmark.ops_sat")
+class DummyBenchmark:
+    pass
+bench_ops_sat.OPSSATBenchmark = DummyBenchmark
+sys.modules.setdefault("spaceai.benchmark.ops_sat", bench_ops_sat)
+cython_stub = types.ModuleType("spaceai.segmentators.cython_functions")
+def _stub(*args, **kwargs):
+    return 0
+cython_stub.apply_transformations_to_channel_cython = _stub
+cython_stub.calculate_slope = _stub
+cython_stub.compute_spectral_centroid = _stub
+cython_stub.moving_average_error = _stub
+cython_stub.spearman_correlation = _stub
+cython_stub.stft_spectral_std = _stub
+sys.modules.setdefault("spaceai.segmentators.cython_functions", cython_stub)
+
+import joblib
+import numpy as np
+import pandas as pd
+
+# Provide a minimal torch stub for dependencies
+torch = types.ModuleType("torch")
+utils = types.ModuleType("torch.utils")
+data_mod = types.ModuleType("torch.utils.data")
+
+class Dataset:
+    pass
+
+def from_numpy(arr):
+    return arr
+
+torch.Tensor = np.ndarray  # type: ignore[attr-defined]
+torch.from_numpy = from_numpy
+
+class DataLoader:
+    def __init__(self, dataset, batch_size=1, shuffle=False):
+        self.dataset = dataset
+
+    def __iter__(self):
+        for i in range(len(self.dataset)):
+            yield self.dataset[i]
+
+    def __len__(self):
+        return len(self.dataset)
+
+class Subset:
+    def __init__(self, dataset, indices):
+        self.dataset = dataset
+        self.indices = indices
+
+    def __len__(self):
+        return len(self.indices)
+
+    def __getitem__(self, idx):
+        return self.dataset[self.indices[idx]]
+
+data_mod.Dataset = Dataset
+data_mod.DataLoader = DataLoader
+data_mod.Subset = Subset
+utils.data = data_mod
+
+torch.utils = utils
+sys.modules.setdefault("torch", torch)
+sys.modules.setdefault("torch.utils", utils)
+sys.modules.setdefault("torch.utils.data", data_mod)
+
+import spaceai.data.esa as esa_module
+esa_module.torch = torch
+
+from sklearn.linear_model import LogisticRegression
+
+from spaceai.benchmark.esa_competition_predictor import ESACompetitionPredictor
+from spaceai.benchmark.esa_competition_training import (
+    ESACompetitionTraining,
+    SegmentedModel,
+)
+from spaceai.data.esa import ESAMission
+
+
+class DummyShapeletMiner:
+    def initialize_kernels(self, *args, **kwargs):
+        pass
+
+
+class DummySegmentator:
+    def __init__(self):
+        self.shapelet_miner = DummyShapeletMiner()
+
+    def segment(self, esa_channel, masks, ensemble_id, train_phase=False):
+        n = len(esa_channel.data)
+        df = pd.DataFrame(
+            {"start": np.arange(n), "end": np.arange(n), "val": esa_channel.data[:, 0]}
+        )
+        return df, esa_channel.anomalies
+
+
+def create_dataset(tmpdir, channel_id="channel_12"):
+    root = os.path.join(tmpdir, "datasets")
+    mission_dir = os.path.join(root, "ESA-Mission1", "ESA-Mission1")
+    os.makedirs(os.path.join(mission_dir, "channels"), exist_ok=True)
+
+    channels = [channel_id]
+    if channel_id != "channel_12":
+        channels.append("channel_12")
+    pd.DataFrame({"Channel": channels, "Group": ["G1"] * len(channels)}).to_csv(
+        os.path.join(mission_dir, "channels.csv"), index=False
+    )
+    pd.DataFrame({"Telecommand": ["telecommand_1"], "Priority": [1]}).to_csv(
+        os.path.join(mission_dir, "telecommands.csv"), index=False
+    )
+    start = datetime(2020, 1, 1)
+    idx = pd.date_range(start, periods=30, freq="S")
+    for ch in channels:
+        channel_df = pd.DataFrame({ch: np.random.rand(30)}, index=idx)
+        channel_df.to_pickle(os.path.join(mission_dir, "channels", f"{ch}.zip"))
+    pd.DataFrame(
+        {
+            "ID": [1],
+            "Channel": [channel_id],
+            "StartTime": [start],
+            "EndTime": [start + timedelta(seconds=5)],
+        }
+    ).to_csv(os.path.join(mission_dir, "labels.csv"), index=False)
+    pd.DataFrame({"ID": [1], "Category": ["Anomaly"]}).to_csv(
+        os.path.join(mission_dir, "anomaly_types.csv"), index=False
+    )
+    chal_dir = os.path.join(root, "ESA-Mission1-challenge")
+    os.makedirs(chal_dir, exist_ok=True)
+    chal_cols = {ch: np.random.rand(20) for ch in channels}
+    chal_cols["telecommand_1"] = np.zeros(20)
+    chal_df = pd.DataFrame(chal_cols)
+    chal_df.to_parquet(os.path.join(chal_dir, "test.parquet"))
+
+    mission = ESAMission(
+        index=1,
+        url_source="",
+        dirname="ESA-Mission1",
+        train_test_split=pd.to_datetime(start + timedelta(seconds=15)),
+        start_date=pd.to_datetime(start),
+        end_date=pd.to_datetime(start + timedelta(seconds=40)),
+        resampling_rule=pd.Timedelta(seconds=1),
+        monotonic_channel_range=(0, 0),
+        parameters=channels,
+        telecommands=["telecommand_1"],
+        target_channels=[channel_id],
+    )
+    return root, mission
+
+
+def test_full_workflow(tmp_path):
+    data_root, mission = create_dataset(tmp_path)
+    segmentator = DummySegmentator()
+    benchmark = ESACompetitionTraining(
+        run_id="run1",
+        exp_dir=str(tmp_path / "exp"),
+        segmentator=segmentator,
+        data_root=data_root,
+    )
+
+    def dummy_run(self, *_args, **_kwargs):
+        model_dir = os.path.join(
+            self.exp_dir, self.run_id, "models", "channel_channel_12"
+        )
+        os.makedirs(model_dir, exist_ok=True)
+        ch_model = SegmentedModel(
+            LogisticRegression().fit([[0, 0, 0], [1, 1, 1]], [0, 1]),
+            segmentator,
+            ensemble_id="e0",
+        )
+        joblib.dump(ch_model, os.path.join(model_dir, "internal_0.pkl"))
+        meta_model = SegmentedModel(
+            LogisticRegression().fit([[0], [1]], [0, 1]),
+            segmentator,
+            ensemble_id="e1",
+        )
+        joblib.dump(meta_model, os.path.join(model_dir, "external_0.pkl"))
+        links = {"external_0": {"mask_id": "m0", "internal_ids": ["internal_0"]}}
+        with open(os.path.join(model_dir, "links.json"), "w") as f:
+            json.dump(links, f)
+        ev_dir = os.path.join(self.exp_dir, self.run_id, "models")
+        os.makedirs(ev_dir, exist_ok=True)
+        joblib.dump(
+            LogisticRegression().fit([[0], [1]], [0, 1]),
+            os.path.join(ev_dir, "event_wise_0.pkl"),
+        )
+
+    benchmark.run = types.MethodType(dummy_run, benchmark)
+    benchmark.run(mission, None, None, None)
+
+    artifacts_dir = os.path.join(str(tmp_path / "exp"), "run1")
+    predictor = ESACompetitionPredictor(artifacts_dir, segmentator)
+    predictor.load_models()
+    assert "external_0" in predictor.meta_models
+    assert "internal_0" in predictor.internal_models
+
+
+def test_training_run(tmp_path):
+    data_root, mission = create_dataset(tmp_path, channel_id="channel_41")
+    segmentator = DummySegmentator()
+    benchmark = ESACompetitionTraining(
+        run_id="run_train",
+        exp_dir=str(tmp_path / "exp"),
+        segmentator=segmentator,
+        data_root=data_root,
+    )
+
+    import spaceai.benchmark.esa_competition_training as training_mod
+    orig_cv = training_mod.cross_validate
+
+    def single_cv(*args, **kwargs):
+        kwargs["n_jobs"] = 1
+        return orig_cv(*args, **kwargs)
+
+    training_mod.cross_validate = single_cv
+
+    from skopt import BayesSearchCV
+    from sklearn.model_selection import TimeSeriesSplit
+
+    def factory():
+        return BayesSearchCV(
+            estimator=LogisticRegression(solver="liblinear"),
+            search_spaces={"C": [1]},
+            cv=TimeSeriesSplit(n_splits=2),
+            n_iter=1,
+        )
+
+    benchmark.run(
+        mission=mission,
+        search_cv_factory=factory,
+        search_cv_factory2=factory,
+        search_cv_factory3=factory,
+        perc_eval1=0.2,
+        perc_eval2=0.1,
+        perc_shapelet=0.1,
+        external_estimators=1,
+        internal_estimators=1,
+        final_estimators=2,
+    )
+
+    artifacts = os.path.join(tmp_path, "exp", "run_train", "models")
+    channel_dir = os.path.join(artifacts, "channel_channel_41")
+    assert glob.glob(os.path.join(channel_dir, "internal_*.pkl"))
+    assert glob.glob(os.path.join(channel_dir, "external_*.pkl"))
+    assert os.path.exists(os.path.join(channel_dir, "links.json"))
+    assert glob.glob(os.path.join(artifacts, "event_wise_*.pkl"))
+


### PR DESCRIPTION
## Summary
- adjust predictor loader to support nested channel paths
- fix default mission choice
- add comprehensive workflow tests with stubs and dataset helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752c79610c832882a6dd62d85306d9