### PR TITLE
Fix Docker build for inference-only image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install --no-cache-dir poetry \
-    && poetry install --no-dev
-
-RUN python spaceai/segmentators/setup.py build_ext --inplace
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    pip install --no-cache-dir cython poetry && \
+    poetry install --no-dev && \
+    python spaceai/segmentators/setup.py build_ext --inplace && \
+    apt-get purge -y build-essential && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 CMD ["python", "inference.py", "--test-parquet", "/data/test.parquet", "--artifacts-dir", "/artifacts", "--output", "/data/submission.csv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ datetime = "^5.5"
 requests = "^2.32.3"
 psutil = "^6.1.0"
 torchdyno = "^0.2.3"
+tslearn = "^0.6.2"
+sktime = "^0.28.0"
+numba = "^0.59.1"
+pymannkendall = "^1.4.2"
+pyarrow = "^15.0.2"
+scikit-optimize = "^0.9.0"
+cython = "^3.0.10"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
## Summary
- add missing runtime dependencies in `pyproject.toml`
- install build tools and cython in Dockerfile before compiling extensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687583325f2c8328b9570c47ad0848d6