### PR TITLE
Define kernel column selector for inference

### DIFF
--- a/examples/inference.py
+++ b/examples/inference.py
@@ -5,6 +5,15 @@ from spaceai.segmentators.esa_segmentator2 import EsaDatasetSegmentator2
 from spaceai.segmentators.shapelet_miner import ShapeletMiner
 
 
+def kernel_column_selector(X):
+    return [
+        c
+        for c in X.columns
+        if (c.startswith("max_kernel") and c.endswith("max_convolution"))
+        or (c.startswith("min_kernel") and c.endswith("min_convolution"))
+    ]
+
+
 def main():
     parser = argparse.ArgumentParser(description="ESA competition inference")
     parser.add_argument("--artifacts-dir", required=True)


### PR DESCRIPTION
## Summary
- declare `kernel_column_selector` in `examples/inference.py` to support loading pipelines that reference this selector

## Testing
- `poetry install --with test` *(fails: All attempts to connect to pypi.org failed)*
- `pytest` *(fails: unrecognized arguments --cov-report=xml --cov-report=term-missing --cov)*
- `pip install joblib` *(fails: Could not find a version that satisfies the requirement joblib)*

------
https://chatgpt.com/codex/tasks/task_b_6899f43685108333b5fdfe012ef40de7