### PR TITLE
Handle mask-specific ensembles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ python inference.py --artifacts-dir experiments/my_run --test-parquet /path/to/t
 ```
 The resulting `submission.csv` follows the format required by the competition.
 
+### External masks
+During training multiple external masking strategies may be applied. Each meta-model and event-wise model is tagged with a
+`mask_id` identifying the mask used during its creation. At inference time the predictor groups meta-models by `mask_id`,
+averages their probabilities and creates one channel column per mask (e.g. `channel_41_ab12cd34`). Event-wise models stored as
+`event_wise_<mask_id>.pkl` are matched with their corresponding columns to produce the final anomaly probabilities.
+
 ## Repository Structure
 - `esa_competition_training.py` – entry point for training the hierarchical ensemble.
 - `inference.py` – script used to run inference and produce the final submission.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -247,6 +247,7 @@ def test_full_workflow(tmp_path):
     predictor.load_models()
     assert "external_0" in predictor.meta_models
     assert "internal_0" in predictor.internal_models
+    assert "0" in predictor.event_models_by_mask
 
 
 def test_training_run(tmp_path):


### PR DESCRIPTION
## Summary
- Group meta-models by `mask_id` and compute per-mask probabilities
- Match mask-specific channel outputs with corresponding event-wise models
- Document how external masks are handled during inference

## Testing
- `poetry install --with test` *(failed: All attempts to connect to pypi.org failed)*
- `pytest -o addopts=""` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_689b343c17948333afc1bd07aaf0e0f6