### PR TITLE
Track models used in latest run for ESA predictor

### DIFF
--- a/tests/test_segment_shapelets_cache.py
+++ b/tests/test_segment_shapelets_cache.py
@@ -1,7 +1,10 @@
+import os
 import sys
 import types
 import numpy as np
 import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Stub cython functions used by the segmentator
 cython_stub = types.ModuleType("spaceai.segmentators.cython_functions")

--- a/tests/test_shapelet_miner.py
+++ b/tests/test_shapelet_miner.py
@@ -1,6 +1,9 @@
+import os
 import sys
 import types
 import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Provide a minimal torch stub to satisfy optional imports
 torch = types.ModuleType("torch")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -232,6 +232,8 @@ def test_full_workflow(tmp_path):
         links = {"external_0": {"mask_id": "m0", "internal_ids": ["internal_0"]}}
         with open(os.path.join(model_dir, "links.json"), "w") as f:
             json.dump(links, f)
+        with open(os.path.join(model_dir, "used_models.json"), "w") as f:
+            json.dump({"meta_ids": ["external_0"], "internal_ids": ["internal_0"]}, f)
         ev_dir = os.path.join(self.exp_dir, self.run_id, "models")
         os.makedirs(ev_dir, exist_ok=True)
         joblib.dump(
@@ -298,5 +300,6 @@ def test_training_run(tmp_path):
     assert glob.glob(os.path.join(channel_dir, "internal_*.pkl"))
     assert glob.glob(os.path.join(channel_dir, "external_*.pkl"))
     assert os.path.exists(os.path.join(channel_dir, "links.json"))
+    assert os.path.exists(os.path.join(channel_dir, "used_models.json"))
     assert glob.glob(os.path.join(artifacts, "event_wise_*.pkl"))
 


### PR DESCRIPTION
## Summary
- record which internal and meta models are produced during channel training
- load only models listed in `used_models.json` when building predictor
- adapt tests for new metadata and module import paths

## Testing
- `poetry install --with test`
- `pytest -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_689db6176fa48328a4587672c739ffef