### PR TITLE
feat: track used models per mask

### DIFF
--- a/spaceai/benchmark/esa_competition_predictor.py
+++ b/spaceai/benchmark/esa_competition_predictor.py
@@ -74,8 +74,15 @@ class ESACompetitionPredictor(ESACompetitionBenchmark):
             if os.path.exists(used_file):
                 with open(used_file, "r") as f:
                     used = json.load(f)
-                allowed_internal = set(used.get("internal_ids", []))
-                allowed_meta = set(used.get("meta_ids", []))
+                if "internal_ids" in used or "meta_ids" in used:
+                    allowed_internal = set(used.get("internal_ids", []))
+                    allowed_meta = set(used.get("meta_ids", []))
+                else:
+                    allowed_internal = set()
+                    allowed_meta = set()
+                    for info in used.values():
+                        allowed_internal.update(info.get("internal_ids", []))
+                        allowed_meta.update(info.get("meta_ids", []))
 
             links_file = os.path.join(ch_dir, "links.json")
             if os.path.exists(links_file):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -233,7 +233,7 @@ def test_full_workflow(tmp_path):
         with open(os.path.join(model_dir, "links.json"), "w") as f:
             json.dump(links, f)
         with open(os.path.join(model_dir, "used_models.json"), "w") as f:
-            json.dump({"meta_ids": ["external_0"], "internal_ids": ["internal_0"]}, f)
+            json.dump({"m0": {"meta_ids": ["external_0"], "internal_ids": ["internal_0"]}}, f)
         ev_dir = os.path.join(self.exp_dir, self.run_id, "models")
         os.makedirs(ev_dir, exist_ok=True)
         joblib.dump(
@@ -300,6 +300,10 @@ def test_training_run(tmp_path):
     assert glob.glob(os.path.join(channel_dir, "internal_*.pkl"))
     assert glob.glob(os.path.join(channel_dir, "external_*.pkl"))
     assert os.path.exists(os.path.join(channel_dir, "links.json"))
-    assert os.path.exists(os.path.join(channel_dir, "used_models.json"))
+    used_file = os.path.join(channel_dir, "used_models.json")
+    assert os.path.exists(used_file)
+    with open(used_file) as f:
+        used = json.load(f)
+    assert all("internal_ids" in v and "meta_ids" in v for v in used.values())
     assert glob.glob(os.path.join(artifacts, "event_wise_*.pkl"))
 


### PR DESCRIPTION
## Summary
- persist used internal and meta model IDs separately for each external mask
- load new per-mask model mapping in predictor
- update workflow tests for new used model structure

## Testing
- `poetry install --with test`
- `pre-commit run --files spaceai/benchmark/esa_competition_training.py spaceai/benchmark/esa_competition_predictor.py tests/test_workflow.py` (fails: command not found)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dca460d488328af9606ca51052bf4