### PR TITLE
Keep shapelet kernel count in sync

### DIFF
--- a/spaceai/segmentators/esa_segmentator2.py
+++ b/spaceai/segmentators/esa_segmentator2.py
@@ -325,7 +325,7 @@ class EsaDatasetSegmentator2:
         )
 
         df = df.reset_index(drop=True).copy()
-        for i in range(self.shapelet_miner.num_kernels):
+        for i in range(len(self.shapelet_miner.kernels)):
             df[f"kernel_{i}_max_convolution"] = raw_features[:, 2 * i]
             df[f"kernel_{i}_min_convolution"] = raw_features[:, 2 * i + 1]
    

--- a/spaceai/segmentators/shapelet_miner.py
+++ b/spaceai/segmentators/shapelet_miner.py
@@ -187,6 +187,7 @@ class ShapeletMiner:
             else:
                 new_kernels.append(arr)
         self.kernels = new_kernels
+        self.num_kernels = len(self.kernels)
 
         all_payload[ensemble_id] = {
             "mask": [int(mask[0]), int(mask[1])],


### PR DESCRIPTION
## Summary
- iterate shapelet features based on actual kernel list length
- update ShapeletMiner to refresh kernel count

## Testing
- `poetry install --with test`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f24edfbf88328b610219b37bb66bf