### PR TITLE
chore: pin scipy to stable version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ numba = "^0.61.2"
 pyarrow = "^16.0.0"
 scikit-optimize = "^0.9.0"
 sktime = "^0.38.3"
+# SciPy 1.15 introduced MultiUFunc import errors with NumPy 2.x on
+# some platforms. Restrict to the latest 1.14 release for stability.
+scipy = ">=1.14,<1.15"
 cython = "^3.0.10"
 
 [tool.poetry.group.dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,11 @@ numpy==2.1.3
 pandas==2.2.2
 pyarrow==16.0.0
 scikit-learn==1.5.1
-scipy==1.15.2
+# SciPy 1.15.2 caused import errors due to issues with MultiUFunc
+# objects when running on some environments (e.g. Kaggle). Pin to a
+# stable release that works with NumPy 2.x to avoid the runtime
+# ValueError raised during `scipy.special` import.
+scipy==1.14.1
 sktime==0.38.3
 torch==2.4.1
 tqdm==4.66.5


### PR DESCRIPTION
## Summary
- pin scipy to 1.14.x to avoid MultiUFunc import errors with NumPy 2.x
- document pin in requirements and pyproject

## Testing
- `poetry lock` *(fails: All attempts to connect to pypi.org)*
- `pytest` *(fails: unrecognized arguments: --cov-report=xml --cov-report=term-missing --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c0d0e1048328a18c702ee979f690