### PR TITLE
Restore numpy bool alias for NumPy 2 compatibility

### DIFF
--- a/spaceai/__init__.py
+++ b/spaceai/__init__.py
@@ -5,13 +5,16 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Compatibility shims
 # ---------------------------------------------------------------------------
-# NumPy removed several aliases such as ``np.int`` in version 2.0.  Some
-# dependencies (e.g. scikit-optimize) still rely on these names.  To avoid
-# runtime failures when the project is used with newer NumPy releases, we
-# restore the alias if it is missing.  This mirrors the workaround used in the
-# test suite and is safe because it simply points ``np.int`` to the builtin
-# ``int`` type.
+# NumPy removed several aliases such as ``np.int`` and ``np.bool`` in version
+# 2.0.  Some dependencies (e.g. scikit-optimize) still rely on these names. To
+# avoid runtime failures when the project is used with newer NumPy releases, we
+# restore the aliases if they are missing.  This mirrors the workaround used in
+# the test suite and is safe because it simply points ``np.int`` to the builtin
+# ``int`` type and ``np.bool`` to ``np.bool_``.
 if not hasattr(np, "int"):
     np.int = int  # type: ignore[attr-defined]
+
+if not hasattr(np, "bool"):
+    np.bool = np.bool_  # type: ignore[attr-defined]
 
 __version__ = "0.0.1"


### PR DESCRIPTION
## Summary
- restore `np.bool` alias when missing to keep compatibility with libraries that still depend on it

## Testing
- `poetry install --with test` *(fails: pyproject.toml changed significantly since lock file)*
- `PYTEST_ADDOPTS="" pytest -o addopts='' -p no:cov` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a0c579ed1883289854adca9b65b2c6