### PR TITLE
Handle missing optional dependencies and fix numpy bool alias

### DIFF
--- a/spaceai/__init__.py
+++ b/spaceai/__init__.py
@@ -14,6 +14,13 @@ import numpy as np
 if not hasattr(np, "int"):
     np.int = int  # type: ignore[attr-defined]
 if not hasattr(np, "bool"):
-    np.bool = bool  # type: ignore[attr-defined]
+    # ``np.bool`` was removed in NumPy 2.0.  Older dependencies occasionally
+    # still reference it expecting the NumPy scalar type (``np.bool_``), not the
+    # builtin ``bool``.  Assigning the Python ``bool`` type here leads to
+    # failures when libraries check for NumPy specific attributes such as
+    # ``view``.  To remain backwards compatible we therefore alias the missing
+    # name to ``np.bool_`` which replicates the behaviour of the deprecated
+    # alias without breaking libraries that rely on NumPy's boolean dtype.
+    np.bool = np.bool_  # type: ignore[attr-defined]
 
 __version__ = "0.0.1"

--- a/spaceai/benchmark/esa_competition.py
+++ b/spaceai/benchmark/esa_competition.py
@@ -15,7 +15,15 @@ import numpy as np
 import pandas as pd
 from sklearn.base import clone
 from sklearn.model_selection import cross_validate
-from skopt.space import Dimension
+# ``scikit-optimize`` provides the ``Dimension`` class used for defining search
+# spaces.  The package is optional and not available in some lightweight
+# execution environments, hence we attempt to import it lazily and provide a
+# minimal stub when missing so that the rest of the module can still be
+# imported.
+try:  # pragma: no cover - behaviour depends on environment
+    from skopt.space import Dimension  # type: ignore[import-untyped]
+except ModuleNotFoundError:  # pragma: no cover - executed without scikit-optimize
+    from typing import Any as Dimension  # type: ignore[assignment]
 from torch.utils.data import (
     DataLoader,
     Subset,


### PR DESCRIPTION
## Summary
- use `np.bool_` instead of builtin `bool` when recreating deprecated `np.bool` alias
- gracefully handle environments without `requests`, `psutil` or `scikit-optimize`

## Testing
- `poetry install --with test` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*
- `pytest -o addopts=''` *(fails: ModuleNotFoundError: No module named 'skopt')*


------
https://chatgpt.com/codex/tasks/task_e_68a0e0b7d1c88328ab193acedd8271ac